### PR TITLE
Fix: Makes titles of passing and failing tests consistent

### DIFF
--- a/src/FactCheck.jl
+++ b/src/FactCheck.jl
@@ -125,7 +125,7 @@ function Base.show(io::IO, s::Success)
         println(io, "\n<PASSED::>Test Passed")
         println(io, "\n<COMPLETEDIN::>")
     else
-        println(io, "\n<IT::>", replace_lf(s.meta.msg != nothing ? "$(s.meta.msg)" : format_fact(s.expr)))
+        println(io, "\n<IT::>", replace_lf(format_fact(s.expr)))
         println(io, "\n<PASSED::>Test Passed")
         println(io, "\n<COMPLETEDIN::>")
     end

--- a/src/FactCheck.jl
+++ b/src/FactCheck.jl
@@ -113,8 +113,9 @@ function Base.show(io::IO, f::Failure)
 end
 
 function Base.show(io::IO, e::Error)
-    println(io, "\n<IT::>", replace_lf(e.meta.msg != nothing ? "$(e.meta.msg)" : format_fact(e.expr)))
-    println(io, "\n<ERROR::>", replace_lf(sprint(showerror, e.err)))
+    println(io, "\n<IT::>", replace_lf(format_fact(e.expr)))
+    errorMsg = e.meta.msg != nothing ? sprint(print, e.meta.msg) : sprint(showerror, e.err)
+    println(io, "\n<ERROR::>", replace_lf(errorMsg))
     println(io, "\n<LOG::-Stack trace>", replace_lf(sprint(showerror, e.err, e.backtrace)))
     println(io, "\n<COMPLETEDIN::>")
 end

--- a/src/FactCheck.jl
+++ b/src/FactCheck.jl
@@ -120,15 +120,9 @@ function Base.show(io::IO, e::Error)
 end
 
 function Base.show(io::IO, s::Success)
-    if s.rhs == :fact_throws_error
-        println(io, "\n<IT::>", replace_lf(s.meta.msg != nothing ? "$(s.meta.msg)" : "Throws Error"))
-        println(io, "\n<PASSED::>Test Passed")
-        println(io, "\n<COMPLETEDIN::>")
-    else
-        println(io, "\n<IT::>", replace_lf(format_fact(s.expr)))
-        println(io, "\n<PASSED::>Test Passed")
-        println(io, "\n<COMPLETEDIN::>")
-    end
+	println(io, "\n<IT::>", replace_lf(format_fact(s.expr)))
+	println(io, "\n<PASSED::>Test Passed")
+	println(io, "\n<COMPLETEDIN::>")
 end
 
 function Base.show(io::IO, ::Pending)


### PR DESCRIPTION
Code:

```julia
facts("Compare passing and failing") do
  context("With custom message") do
    @fact 7 --> 7 "7 is 7"
    @fact 7 --> 13 "13 is 13"
  end
  context("Without custom message") do
    @fact 7 --> 7
    @fact 7 --> 13
  end
  context("@fact_throws with custom message") do
    @fact_throws TypeError typeassert(1.0, Int) "Expected error not thrown"
    @fact_throws TypeError typeassert(1, Int) "Expected error not thrown"
  end      
  context("@fact_throws without custom message") do
    @fact_throws TypeError typeassert(1.0, Int)
    @fact_throws TypeError typeassert(1, Int)
  end    
end
```

Current Codewars reporter:

![image](https://user-images.githubusercontent.com/23709795/225540440-3b1dbb87-1c7b-4e67-beb1-daf2ccbd7689.png)


Proposed reporter:

![image](https://user-images.githubusercontent.com/23709795/225540735-10f92908-e5be-4901-bab1-cf054bbe873e.png)
